### PR TITLE
core: fix session open pooling

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -947,25 +947,26 @@ func isRollPublic(i *discordgo.Interaction) bool {
 func InteractionGolemancy(ctx context.Context) {
 	s, i, _ := FromContext(ctx)
 	if !DiceGolem.IsOwner(UserFromInteraction(i)) {
-		if err := MeasureInteractionRespond(s.InteractionRespond, i, newEphemeralResponse("This command is reserved for bot administrators.")); err != nil {
+		if err := MeasureInteractionRespond(s.InteractionRespond, i, newEphemeralResponse("This command is restricted to bot owners.")); err != nil {
 			logger.Error("error sending response", zap.Error(err))
 		}
 		return
 	}
 	data := i.ApplicationCommandData()
 	group := data.Options[0]
+	logger.Info("golemancy command received", zap.Any("data", data))
 	switch group.Name {
 	case "restart":
 		subcommand := group.Options[0]
 		switch subcommand.Name {
 		case "session":
 			id := getOptionByName(subcommand.Options, "id").IntValue()
-			if session := DiceGolem.Sessions[id]; session != nil {
+			if targetSession := DiceGolem.Sessions[id]; targetSession != nil {
 				MeasureInteractionRespond(s.InteractionRespond, i, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 				})
 				now := time.Now()
-				if err := restartSession(session); err != nil {
+				if err := restartSession(targetSession); err != nil {
 					logger.Error("error restarting session", zap.Error(err), zap.Int("shard", s.ShardID))
 				}
 				if _, err := s.InteractionResponseEdit(i, &discordgo.WebhookEdit{

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 				Footer:      makeEmbedFooter(),
 			},
 		},
+		Flags: discordgo.MessageFlagsSuppressNotifications,
 	})
 
 	go func() {
@@ -268,6 +269,8 @@ func RouteInteractionCreate(s *discordgo.Session, ic *discordgo.InteractionCreat
 
 	logger.Debug("interaction type", zap.String("type", i.Type.String()))
 
+	// FIXME: this duration needs to be lengthier, and cut back depending on
+	// interaction type (ex. roll vs. session restart)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	ctx = NewContext(ctx, s, i, nil)
@@ -319,7 +322,6 @@ func RouteInteractionCreate(s *discordgo.Session, ic *discordgo.InteractionCreat
 				_ = MeasureInteractionRespond(s.InteractionRespond, i, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseDeferredMessageUpdate,
 				})
-				// cacheRollExpression(s, i, rollData.Expression)
 			}
 		} else if handle, ok := handlers[id]; ok {
 			// if it was a generic action button, handle the press


### PR DESCRIPTION
- Addresses a logic error in the `DiceGolem.Open()` method where work groups were not allowed to finish before the method returned
- Improves logging for `/golemancy` commands