### PR TITLE
fix typo in description

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -97,7 +97,7 @@ var CommandsGlobalChat = []*discordgo.ApplicationCommand{
 			},
 			{
 				Name:        "expressions",
-				Description: "Clear your saved roll exressions.",
+				Description: "Clear your saved roll expressions.",
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
 			},
 		},


### PR DESCRIPTION
Fixes a typo in the description of the `/clear expressions` command.